### PR TITLE
Sync the Layer A and ISOBMFF ports with upstream main

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,24 @@ Live demo: [https://ivanusto.github.io/unmark-web/](https://ivanusto.github.io/u
 
 | Input | Browser engine | Server engine (`server.py`) |
 | --- | --- | --- |
-| Pasted text / `.txt` | Layer A: zero-width & bidi controls, variation selectors, tag chars, PUA, other `Cf`; space homoglyphs; optional NFKC / Latin confusables. Preserves load-bearing invisibles (emoji ZWJ/VS16, Persian/Indic ZWNJ, flag tags, Mongolian FVS, Khmer vowels, Hangul fillers, Arabic Cf) exactly like upstream, with a "paranoid" toggle. | same |
+| Pasted text / `.txt` | Layer A: zero-width & bidi controls, variation selectors, tag chars, PUA, Unicode noncharacters, reserved default-ignorables, other `Cf`; space homoglyphs; optional NFKC / Latin confusables. Preserves load-bearing invisibles (emoji ZWJ/VS16, Persian/Indic ZWNJ, flag tags, Mongolian FVS, Khmer vowels, Hangul fillers, Arabic Cf, and layout format controls next to their own script: Egyptian quadrat, Duployan, musical beaming) exactly like upstream, with a "paranoid" toggle. | same |
 | `.md` `.html` `.svg` | Layer A on the text only (metadata tags/frontmatter untouched — flagged in the UI) | full container cleaning (frontmatter keys, `<meta generator>`, XMP, …) |
 | PNG / JPEG / WebP / AVIF / HEIC | drops `tEXt/zTXt/iTXt/eXIf/caBX/c2*` chunks, `APPn` (except JFIF) + `COM` segments, `EXIF/XMP/ICCP/C2PA` RIFF chunks with VP8X flag fix-up, and `jumb/c2pa/uuid` (XMP) ISOBMFF boxes plus their `meta` sub-boxes. Pixels are untouched (no canvas re-encode). "Keep non-AI metadata" mode only drops blocks with AI/C2PA hints. | same, plus optional pixel-domain backends if installed |
 | BMP / GIF / TIFF | BMP: drops the trailing bytes after the pixel payload (the only place BMP metadata can live) and rewrites the file-size field. GIF: drops comment and XMP/unknown application extensions, keeping NETSCAPE2.0 looping and ICC. TIFF (classic and BigTIFF): walks the IFD chains and drops XMP/EXIF/GPS/IPTC/Photoshop/MakerNote tags, patching each IFD in place so strip and tile offsets stay valid. | same |
 | PDF / DOCX / ODT / EPUB | — (needs server) | yes |
 | Statistical text watermarks (Kirchenbauer / KGW, SynthID-Text) | **detect only**, via the optional local [sidecar](sidecar/README.md) (needs a model and the generator's key); never removed — see upstream Layer B for rewriting | via upstream `/detect` (MarkLLM harness) when the server advertises text detectors |
 | Pixel watermarks (SynthID image, …) | **no** | via upstream backends only |
+
+Two consequences of the container rules that surprise people:
+
+* **A cleaned AVIF or HEIC is the same size as the original.** A dropped ISOBMFF box is
+  overwritten with an equal-size `free` box rather than spliced out, because closing the gap
+  would shift every absolute media offset later in the file and break the image. The metadata
+  really is gone: the `free` payload is zeroed.
+* **A truncated file keeps its truncated tail.** If a download was interrupted, the last PNG
+  chunk or ISOBMFF box declares more bytes than the file holds. That tail is copied through
+  verbatim and reported as an action, so a recoverable image is not turned into an unopenable
+  husk that claims it was already clean.
 
 ## Connecting a server
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -22,13 +22,22 @@
 
 | 輸入 | 瀏覽器引擎 | 伺服器引擎（`server.py`） |
 | --- | --- | --- |
-| 貼上的文字 / `.txt` | Layer A：零寬與 bidi 控制字元、變體選擇符、tag 字元、PUA、其他 `Cf`；空白同形字；可選的 NFKC／拉丁易混字元處理。與上游一致地保留具功能性的隱形字元（emoji 的 ZWJ/VS16、波斯文／印度系文字的 ZWNJ、旗幟 tag、蒙古文 FVS、高棉文母音、諺文填充字元、阿拉伯文 `Cf`），並提供「偏執模式」開關。 | 同左 |
+| 貼上的文字 / `.txt` | Layer A：零寬與 bidi 控制字元、變體選擇符、tag 字元、PUA、Unicode 非字元、保留的預設可忽略字元、其他 `Cf`；空白同形字；可選的 NFKC／拉丁易混字元處理。與上游一致地保留具功能性的隱形字元（emoji 的 ZWJ/VS16、波斯文／印度系文字的 ZWNJ、旗幟 tag、蒙古文 FVS、高棉文母音、諺文填充字元、阿拉伯文 `Cf`，以及緊鄰自身書寫系統的排版控制字元：埃及聖書體象限、Duployan 速記、音樂符號連桿），並提供「偏執模式」開關。 | 同左 |
 | `.md` `.html` `.svg` | 僅對文字內容套用 Layer A（中繼資料標籤／frontmatter 不動，UI 會標示） | 完整容器清理（frontmatter 鍵、`<meta generator>`、XMP……） |
 | PNG / JPEG / WebP / AVIF / HEIC | 移除 `tEXt/zTXt/iTXt/eXIf/caBX/c2*` 區塊、`APPn`（JFIF 除外）與 `COM` 區段、`EXIF/XMP/ICCP/C2PA` RIFF 區塊並修正 VP8X 旗標，以及 ISOBMFF 的 `jumb/c2pa/uuid`（XMP）盒與其 `meta` 子盒。像素不動（不經 canvas 重新編碼）。「保留非 AI 中繼資料」模式只移除帶有 AI／C2PA 跡象的區塊。 | 同左，若有安裝則額外提供像素域後端 |
 | BMP / GIF / TIFF | BMP：移除像素資料之後的尾端位元組（BMP 中繼資料唯一可能存在的位置）並改寫檔案大小欄位。GIF：移除註解與 XMP／未知的 application extension，保留 NETSCAPE2.0 循環與 ICC。TIFF（classic 與 BigTIFF）：走訪 IFD 鏈並移除 XMP／EXIF／GPS／IPTC／Photoshop／MakerNote 標籤，逐一原地修補 IFD，讓 strip 與 tile 的 offset 保持有效。 | 同左 |
-| PDF / DOCX / ODT / EPUB | ，（需要伺服器） | 支援 |
+| PDF / DOCX / ODT / EPUB | 不支援（需要伺服器） | 支援 |
 | 統計式文字浮水印（Kirchenbauer／KGW、SynthID-Text） | **只偵測**，透過選用的本機 [sidecar](sidecar/README.md)（需要模型與生成端的 key）；不移除，改寫請見上游 Layer B | 伺服器宣告文字偵測器時走上游 `/detect`（MarkLLM harness） |
 | 像素式浮水印（SynthID image 等） | **不支援** | 僅能透過上游後端 |
+
+容器處理有兩個常讓人意外的結果：
+
+* **清理後的 AVIF／HEIC 檔案大小不變。** 被移除的 ISOBMFF 盒是就地覆寫成等長的 `free` 盒，
+  而不是抽掉。抽掉會讓檔案後段所有絕對 offset 位移，圖就壞了。中繼資料確實已經消失：
+  `free` 盒的內容是全零。
+* **被截斷的檔案會保留截斷的尾段。** 下載中斷時，最後一個 PNG chunk 或 ISOBMFF 盒宣告的
+  長度會超出檔案實際內容。那段尾巴會原樣保留並列進動作清單，避免把一個還救得回來的圖
+  變成打不開的空殼，還宣稱它本來就是乾淨的。
 
 ## 連接伺服器
 

--- a/js/image_meta.js
+++ b/js/image_meta.js
@@ -264,7 +264,7 @@
       const length = be32(u8, pos);
       const type = latin1(u8.subarray(pos + 4, pos + 8));
       const start = pos + 8, end = start + length;
-      if (end + 4 > u8.length) { yield { type, truncated: true }; return; }
+      if (end + 4 > u8.length) { yield { type, truncated: true, offset: pos }; return; }
       yield { type, payload: u8.subarray(start, end), raw: u8.subarray(pos, end + 4) };
       if (type === "IEND") return;
       pos = end + 4;
@@ -347,7 +347,10 @@
     const findings = []; let hasC2pa = false, hasAi = false;
     if (detectFormat(u8) !== "png") return { hasC2pa: false, hasAi: false, findings: ["not a PNG"] };
     for (const c of pngChunks(u8)) {
-      if (c.truncated) { findings.push(`truncated chunk ${c.type}`); break; }
+      // Upstream renders the chunk type with Python's repr() here, so the
+      // literal b'...' wrapper is part of the finding string the parity
+      // suite compares. Cosmetic upstream, load-bearing for us.
+      if (c.truncated) { findings.push(`truncated chunk b'${c.type}'`); break; }
       if (c.type === "caBX" || c.type === "juMB" || c.type === "jumb" || c.type.startsWith("c2")) {
         hasC2pa = true; findings.push(`PNG chunk ${c.type} (possible C2PA container)`);
       }
@@ -377,7 +380,16 @@
     if (detectFormat(u8) !== "png") throw new Error("not PNG");
     const actions = []; const out = [new Uint8Array(PNG_SIG)];
     for (const c of pngChunks(u8)) {
-      if (c.truncated) break;
+      if (c.truncated) {
+        // A truncated chunk (an interrupted download): copy the remainder
+        // verbatim instead of dropping it. Dropping turned a recoverable image
+        // into an unopenable husk while reporting "already clean" (upstream
+        // #170). Recorded as an action so the run is never mistaken for an
+        // ordinary no-op clean.
+        out.push(u8.subarray(c.offset));
+        actions.push(`kept ${u8.length - c.offset} bytes of truncated chunk ${c.type} tail (file truncated)`);
+        break;
+      }
       let drop = false;
       if (c.type === "eXIf" || c.type === "caBX" || c.type.startsWith("c2")) {
         drop = true; actions.push(`drop chunk ${c.type}`);
@@ -529,7 +541,10 @@
   // ------------------------------------------------------- AVIF / HEIC (ISOBMFF)
   const XMP_UUID = [0xbe, 0x7a, 0xcf, 0xcb, 0x97, 0xa9, 0x42, 0xe8, 0x9c, 0x71, 0x99, 0x94, 0x91, 0xe3, 0xaf, 0xac];
 
-  /** Parse top-level or container boxes -> [{fourcc, payload, size, headerSize}]. */
+  /* Parse top-level or container boxes. Returns { boxes, scannedEnd }, where
+   * scannedEnd is the offset the walk stopped at: the start of the first box
+   * that could not be parsed (one whose declared size overruns the data, or a
+   * run of fewer than 8 trailing bytes), or `end` when everything parsed. */
   function parseIsobmffBoxes(u8, start = 0, end = null) {
     if (end === null) end = u8.length;
     const boxes = [];
@@ -549,7 +564,7 @@
       boxes.push({ fourcc, payload: u8.subarray(pos + headerSize, pos + size), size, headerSize });
       pos += size;
     }
-    return boxes;
+    return { boxes, scannedEnd: pos };
   }
 
   const isC2paBox = (fourcc) => fourcc === "jumb" || fourcc === "c2pa" || fourcc.toLowerCase().startsWith("c2");
@@ -559,8 +574,18 @@
     const F = fmt.toUpperCase();
     const findings = [];
     let hasC2pa = false, hasAi = false;
-    const boxes = parseIsobmffBoxes(u8);
-    if (!boxes.length) return { hasC2pa: false, hasAi: false, findings: [`not a valid ${F} (no ISOBMFF boxes found)`] };
+    const { boxes } = parseIsobmffBoxes(u8);
+    if (!boxes.length) {
+      // Box parsing failed (typically the first box's size overruns a truncated
+      // download), which is exactly when the whole-file byte scan is most
+      // useful. Every sibling inspector still runs its equivalent after a
+      // truncation, so run it here too and report the parse failure alongside
+      // whatever it found (upstream #167).
+      const whole = containsAny(u8, C2PA_MARKERS);
+      if (whole.length) { hasC2pa = true; findings.push(`byte-scan C2PA markers: ${whole.slice(0, 6).join(", ")}`); }
+      findings.push(`not a valid ${F} (no ISOBMFF boxes found)`);
+      return { hasC2pa, hasAi: hasAi || hasC2pa, findings };
+    }
 
     const strong = (hits, set) => hits.some((h) => set.has(h.toLowerCase()));
 
@@ -583,7 +608,7 @@
           }
         }
       } else if (fourcc === "meta") {
-        for (const sub of parseIsobmffBoxes(payload, 4)) {
+        for (const sub of parseIsobmffBoxes(payload, 4).boxes) {
           const sName = sub.fourcc;
           if (isC2paBox(sName)) {
             hasC2pa = true;
@@ -615,49 +640,92 @@
     return { hasC2pa, hasAi: hasAi || hasC2pa, findings };
   }
 
-  const isobmffBox = (fourcc, payload) => concat([new Uint8Array(packBe32(payload.length + 8)), enc.encode(fourcc), payload]);
+  /* Serialize an ISOBMFF box, preserving the width of its original header so a
+   * 64-bit box stays 64-bit and every later absolute offset keeps its meaning. */
+  function buildIsobmffBox(fourcc, payload, headerSize = 8) {
+    const size = payload.length + headerSize;
+    const head = headerSize === 16
+      ? packBe32(1).concat([...enc.encode(fourcc)], packU64(size, false))
+      : packBe32(size).concat([...enc.encode(fourcc)]);
+    return concat([new Uint8Array(head), payload]);
+  }
+
+  /* An equal-size `free` box to put where a dropped box used to be. Rewriting in
+   * place instead of closing the gap is what keeps absolute media offsets valid
+   * (upstream #183); the cleaned file therefore keeps its original length. */
+  const isobmffFreeBox = (size, headerSize = 8) =>
+    buildIsobmffBox("free", new Uint8Array(size - headerSize), headerSize);
 
   function stripIsobmff(u8, fmt, { stripAllMetadata = true } = {}) {
     const F = fmt.toUpperCase();
-    const boxes = parseIsobmffBoxes(u8);
+    const { boxes, scannedEnd } = parseIsobmffBoxes(u8);
     if (!boxes.length) throw new Error(`not a valid ${F} (no ISOBMFF boxes)`);
+    // scannedEnd is where the box walk stopped: the parser halts at the first
+    // box whose declared size overruns the data (a truncated download). The
+    // rebuild below used to emit only the boxes that parsed, dropping a
+    // truncated mdat (the actual coded image) while reporting "already clean"
+    // (upstream #170); the tail is appended verbatim afterwards instead.
     const actions = [];
     const out = [];
 
-    for (const { fourcc, payload } of boxes) {
-      if (isC2paBox(fourcc)) { actions.push(`drop top-level ${fourcc} box (C2PA/JUMBF)`); continue; }
+    for (const { fourcc, payload, size, headerSize } of boxes) {
+      if (isC2paBox(fourcc)) {
+        actions.push(`drop top-level ${fourcc} box (C2PA/JUMBF)`);
+        out.push(isobmffFreeBox(size, headerSize)); continue;
+      }
 
       if (fourcc === "uuid") {
-        if (isXmpUuid(payload)) { actions.push(`drop top-level ${fourcc} box (XMP metadata)`); continue; }
+        if (isXmpUuid(payload)) {
+          actions.push(`drop top-level ${fourcc} box (XMP metadata)`);
+          out.push(isobmffFreeBox(size, headerSize)); continue;
+        }
         if (stripAllMetadata || containsAny(payload, ALL_HINTS).length) {
-          actions.push(`drop top-level ${fourcc} box (UUID metadata)`); continue;
+          actions.push(`drop top-level ${fourcc} box (UUID metadata)`);
+          out.push(isobmffFreeBox(size, headerSize)); continue;
         }
       }
 
       if (fourcc === "meta") {
         const verflags = payload.length >= 4 ? payload.subarray(0, 4) : new Uint8Array(4);
         const cleanSub = [];
-        for (const sub of parseIsobmffBoxes(payload, 4)) {
+        for (const sub of parseIsobmffBoxes(payload, 4).boxes) {
           const sName = sub.fourcc;
-          if (isC2paBox(sName)) { actions.push(`drop meta sub-box ${sName} (C2PA/JUMBF)`); continue; }
+          if (isC2paBox(sName)) {
+            actions.push(`drop meta sub-box ${sName} (C2PA/JUMBF)`);
+            cleanSub.push(isobmffFreeBox(sub.size, sub.headerSize)); continue;
+          }
           if (sName === "uuid") {
-            if (isXmpUuid(sub.payload)) { actions.push(`drop meta sub-box ${sName} (XMP metadata)`); continue; }
+            if (isXmpUuid(sub.payload)) {
+              actions.push(`drop meta sub-box ${sName} (XMP metadata)`);
+              cleanSub.push(isobmffFreeBox(sub.size, sub.headerSize)); continue;
+            }
             if (stripAllMetadata || containsAny(sub.payload, ALL_HINTS).length) {
-              actions.push(`drop meta sub-box ${sName} (UUID metadata)`); continue;
+              actions.push(`drop meta sub-box ${sName} (UUID metadata)`);
+              cleanSub.push(isobmffFreeBox(sub.size, sub.headerSize)); continue;
             }
           }
           if (sName === "xml " || sName === "bxml") {
             if (stripAllMetadata || containsAny(sub.payload, ALL_HINTS).length) {
-              actions.push(`drop meta sub-box ${sName} (XML metadata)`); continue;
+              actions.push(`drop meta sub-box ${sName} (XML metadata)`);
+              cleanSub.push(isobmffFreeBox(sub.size, sub.headerSize)); continue;
             }
           }
-          cleanSub.push(isobmffBox(sName, sub.payload));
+          cleanSub.push(buildIsobmffBox(sName, sub.payload, sub.headerSize));
         }
-        out.push(isobmffBox("meta", concat([verflags, concat(cleanSub)])));
+        out.push(buildIsobmffBox("meta", concat([verflags, concat(cleanSub)]), headerSize));
         continue;
       }
 
-      out.push(isobmffBox(fourcc, payload));
+      out.push(buildIsobmffBox(fourcc, payload, headerSize));
+    }
+
+    if (scannedEnd < u8.length) {
+      const tail = u8.subarray(scannedEnd);
+      out.push(tail);
+      // An 8-byte header whose box overruns the data is a truncated download
+      // worth reporting; fewer than 8 leftover bytes is merely trailing junk,
+      // kept verbatim without claiming the file was truncated (upstream #170).
+      if (tail.length >= 8) actions.push(`kept ${tail.length} bytes of truncated tail (file truncated)`);
     }
 
     if (!actions.length) actions.push(`no ${F} metadata boxes removed (already clean or none matched)`);

--- a/js/layer_a.js
+++ b/js/layer_a.js
@@ -6,9 +6,10 @@
  * the "load-bearing invisible" preservation rules (emoji glue, CJK/Mongolian
  * variation selectors, script joiners, complete flag tag sequences, Mongolian
  * FVS, Khmer inherent vowels, Hangul fillers, RTL directional marks and paired
- * embeddings, orthographic Arabic/Syriac Cf marks) and the Cf catch-all mirror
- * upstream so that browser output matches the Python service byte-for-byte for
- * the same options. tests/test_layer_a_parity.py enforces that.
+ * embeddings, orthographic Arabic/Syriac Cf marks, visible-layout format
+ * controls next to their own script) and the Cf catch-all mirror upstream so
+ * that browser output matches the Python service byte-for-byte for the same
+ * options. tests/test_layer_a_parity.py enforces that.
  *
  * Works as a plain <script> (exposes window.LayerA) and as a CommonJS module.
  */
@@ -17,7 +18,7 @@
 
   const STRIP_CODEPOINTS = new Set([
     0x00ad, 0x034f, 0x061c, 0x115f, 0x1160, 0x17b4, 0x17b5,
-    0x180b, 0x180c, 0x180d, 0x180e,
+    0x180b, 0x180c, 0x180d, 0x180e, 0x180f,
     0x200b, 0x200c, 0x200d, 0x200e, 0x200f,
     0x202a, 0x202b, 0x202c, 0x202d, 0x202e,
     0x2060, 0x2061, 0x2062, 0x2063, 0x2064,
@@ -26,6 +27,7 @@
     0xfeff,
     0xfe00, 0xfe01, 0xfe02, 0xfe03, 0xfe04, 0xfe05, 0xfe06, 0xfe07,
     0xfe08, 0xfe09, 0xfe0a, 0xfe0b, 0xfe0c, 0xfe0d, 0xfe0e, 0xfe0f,
+    0x3164, 0xffa0,
     0xfff9, 0xfffa, 0xfffb,
   ]);
 
@@ -63,9 +65,28 @@
     0x0600, 0x0601, 0x0602, 0x0603, 0x0604, 0x0605, 0x06dd, 0x070f, 0x08e2,
     0x110bd, 0x110cd,
   ]);
-  const MONGOLIAN_FVS = new Set([0x180b, 0x180c, 0x180d]);
+  const MONGOLIAN_FVS = new Set([0x180b, 0x180c, 0x180d, 0x180f]);
   const KHMER_VOWELS = new Set([0x17b4, 0x17b5]);
-  const HANGUL_FILLERS = new Set([0x115f, 0x1160]);
+  const HANGUL_FILLERS = new Set([0x115f, 0x1160, 0x3164, 0xffa0]);
+
+  /* Visible-layout format controls: Egyptian hieroglyph quadrat controls,
+   * Duployan shorthand overlap/step controls and musical beam/tie/slur/phrase
+   * controls are Cf but visibly govern how their own script renders. Next to
+   * that script they are document body, not carriers; floating between
+   * unrelated text they stay strip-class. Each context range covers the
+   * script block and the controls themselves, so control runs survive whole. */
+  const LAYOUT_CF_CONTROLS = [
+    [0x13430, 0x13440, 0x13000, 0x14400], // Egyptian hieroglyphs
+    [0x1bca0, 0x1bca4, 0x1bc00, 0x1bca4], // Duployan shorthand
+    [0x1d173, 0x1d17b, 0x1d100, 0x1d200], // musical symbols
+  ];
+  /** [scriptStart, scriptEnd) for a layout Cf control, else null. */
+  function layoutCfScript(cp) {
+    for (const [cStart, cEnd, sStart, sEnd] of LAYOUT_CF_CONTROLS) {
+      if (cp >= cStart && cp < cEnd) return [sStart, sEnd];
+    }
+    return null;
+  }
 
   const RE_CF = /^\p{Cf}$/u;
   const RE_LM = /^[\p{L}\p{M}]$/u;
@@ -76,13 +97,38 @@
   const isPrivateUse = (cp) =>
     (cp >= 0xe000 && cp <= 0xf8ff) || (cp >= 0xf0000 && cp <= 0xffffd) || (cp >= 0x100000 && cp <= 0x10fffd);
 
+  /* The 66 Unicode noncharacters: U+FDD0..U+FDEF plus U+nFFFE/U+nFFFF at the end
+   * of every plane. Permanently reserved for internal use and prohibited in
+   * interchange (TUS 23.7), so any occurrence here is contraband. They render as
+   * nothing or tofu, survive normalisation and can never be assigned, so
+   * stripping them carries no future-Unicode risk. */
+  const isNoncharacter = (cp) => (cp >= 0xfdd0 && cp <= 0xfdef) || (cp & 0xfffe) === 0xfffe;
+
+  /* Unassigned code points with Other_Default_Ignorable_Code_Point=Yes: reserved
+   * for future default-ignorable characters, so conformant renderers already
+   * display them invisibly and normalisation preserves them. They have no
+   * legitimate use in interchange (conformance clause C7), which makes them ideal
+   * covert carriers. Written out as explicit ranges, never as a "category Cn"
+   * rule: the Unicode version behind \p{Cn} moves with the engine, so a Cn rule
+   * would destroy freshly assigned real characters. Re-check these ranges on
+   * Unicode version bumps, exactly as happened when U+180F became Mongolian FVS4
+   * in Unicode 14. */
+  const RESERVED_IGNORABLE_CPS = new Set([0x2065, 0xe0000]);
+  const RESERVED_IGNORABLE_RANGES = [[0xfff0, 0xfff9], [0xe0080, 0xe0100], [0xe01f0, 0xe1000]];
+  const isReservedIgnorable = (cp) =>
+    RESERVED_IGNORABLE_CPS.has(cp) || RESERVED_IGNORABLE_RANGES.some(([lo, hi]) => cp >= lo && cp < hi);
+
   function isStripCp(cp) {
-    return STRIP_CODEPOINTS.has(cp) || inVsSupplement(cp) || (cp >= 0xe0001 && cp <= 0xe007f) || isPrivateUse(cp);
+    if (STRIP_CODEPOINTS.has(cp) || inVsSupplement(cp) || (cp >= 0xe0001 && cp <= 0xe007f)) return true;
+    if (isNoncharacter(cp) || isReservedIgnorable(cp)) return true;
+    return isPrivateUse(cp);
   }
 
   function stripKind(cp) {
     if (cp >= 0xe0001 && cp <= 0xe007f) return "tag_chars";
-    if (inVsSupplement(cp) || (cp >= 0xfe00 && cp <= 0xfe0f) || (cp >= 0x180b && cp <= 0x180d)) return "variation_selector";
+    if (isNoncharacter(cp)) return "noncharacter";
+    if (isReservedIgnorable(cp)) return "reserved_ignorable";
+    if (inVsSupplement(cp) || (cp >= 0xfe00 && cp <= 0xfe0f) || MONGOLIAN_FVS.has(cp)) return "variation_selector";
     if (BIDI_CPS.has(cp)) return "bidi";
     if (ZW_FAMILY.has(cp)) return "zwj_family";
     if (isPrivateUse(cp)) return "private_use";
@@ -121,12 +167,16 @@
     (cp >= 0xf900 && cp <= 0xfaff) || (cp >= 0x20000 && cp <= 0x323af);
   const isMongolianBase = (cp) => cp >= 0x1800 && cp <= 0x18af;
   const isVariationSelector = (cp) =>
-    inVsSupplement(cp) || (cp >= 0xfe00 && cp <= 0xfe0f) || (cp >= 0x180b && cp <= 0x180d);
+    inVsSupplement(cp) || (cp >= 0xfe00 && cp <= 0xfe0f) || MONGOLIAN_FVS.has(cp);
 
   const isMongolianLetter = (cp) => cp >= 0x1800 && cp <= 0x18af && RE_L.test(cat(cp));
   const isKhmerLetter = (cp) => cp >= 0x1780 && cp <= 0x17ff && RE_L.test(cat(cp));
+  /* Conjoining jamo plus the compatibility and halfwidth presentation forms, so
+   * each filler can follow letters of its own form: U+115F/U+1160 after
+   * conjoining jamo, U+3164 after compatibility jamo, U+FFA0 after halfwidth. */
   const isHangulJamo = (cp) =>
-    (cp >= 0x1100 && cp <= 0x11ff) || (cp >= 0xa960 && cp <= 0xa97c) || (cp >= 0xd7b0 && cp <= 0xd7c6);
+    (cp >= 0x1100 && cp <= 0x11ff) || (cp >= 0xa960 && cp <= 0xa97c) || (cp >= 0xd7b0 && cp <= 0xd7c6) ||
+    (cp >= 0x3131 && cp <= 0x318e) || (cp >= 0xffa1 && cp <= 0xffdc);
 
   function isGlue(cp) {
     return EMOJI_GLUE.has(cp) || isVariationSelector(cp) || SCRIPT_JOINERS.has(cp) || inTagRange(cp) ||
@@ -180,7 +230,7 @@
     if (PRESERVABLE_BIDI_CPS.has(cp) && !stripBidi) return ["keep", cat(cp), null];
     if (prevInputCp !== null && !stripEmojiGlue) {
       if (inVsSupplement(cp) && isCjkIdeograph(prevInputCp)) return ["keep", cat(cp), null];
-      if (cp >= 0x180b && cp <= 0x180d && isMongolianBase(prevInputCp)) return ["keep", cat(cp), null];
+      if (MONGOLIAN_FVS.has(cp) && isMongolianBase(prevInputCp)) return ["keep", cat(cp), null];
       if (cp >= 0xfe00 && cp <= 0xfe0d && isCjkIdeograph(prevInputCp)) return ["keep", cat(cp), null];
     }
     if (EMOJI_GLUE.has(cp) && !stripEmojiGlue) {
@@ -199,6 +249,11 @@
       if (KHMER_VOWELS.has(cp) && prevKeptCp !== null && isKhmerLetter(prevKeptCp)) return ["keep", cat(cp), null];
       if (HANGUL_FILLERS.has(cp) && prevKeptCp !== null && isHangulJamo(prevKeptCp)) return ["keep", cat(cp), null];
       if (ORTHOGRAPHIC_CF.has(cp)) return ["keep", cat(cp), null];
+      const script = layoutCfScript(cp);
+      if (script !== null) {
+        const inScript = (n) => n !== null && n >= script[0] && n < script[1];
+        if (inScript(prevInputCp) || inScript(nextInputCp)) return ["keep", cat(cp), null];
+      }
     }
     if (isStripCp(cp)) return ["strip", "", stripKind(cp)];
     if (normalizeSpaces && SPACE_HOMOGLYPHS.has(cp)) return ["replace", SPACE_HOMOGLYPHS.get(cp), "space"];
@@ -209,6 +264,7 @@
 
   const NAMES = {
     0x00ad: "SOFT HYPHEN", 0x034f: "COMBINING GRAPHEME JOINER", 0x061c: "ARABIC LETTER MARK",
+    0x180f: "MONGOLIAN FREE VARIATION SELECTOR FOUR", 0x3164: "HANGUL FILLER", 0xffa0: "HALFWIDTH HANGUL FILLER",
     0x180e: "MONGOLIAN VOWEL SEPARATOR", 0x200b: "ZERO WIDTH SPACE", 0x200c: "ZERO WIDTH NON-JOINER",
     0x200d: "ZERO WIDTH JOINER", 0x200e: "LEFT-TO-RIGHT MARK", 0x200f: "RIGHT-TO-LEFT MARK",
     0x202a: "LEFT-TO-RIGHT EMBEDDING", 0x202b: "RIGHT-TO-LEFT EMBEDDING", 0x202c: "POP DIRECTIONAL FORMATTING",
@@ -228,6 +284,8 @@
       else if (inVsSupplement(cp)) name = "VARIATION SELECTOR-" + (cp - 0xe0100 + 17);
       else if (inTagRange(cp) || cp === 0xe0001) name = "TAG CHARACTER";
       else if (isPrivateUse(cp)) name = "PRIVATE USE";
+      else if (isNoncharacter(cp)) name = "NONCHARACTER";
+      else if (isReservedIgnorable(cp)) name = "RESERVED DEFAULT-IGNORABLE";
       else if (LATIN_CONFUSABLES.has(cp)) name = "CONFUSABLE OF '" + LATIN_CONFUSABLES.get(cp) + "'";
       else name = "UNKNOWN";
     }
@@ -404,7 +462,8 @@
     return { length: cps.length, suspicious_total: total, hits, notes };
   }
 
-  const api = { clean, inspect, decide, isGlue, charLabel, STRIP_CODEPOINTS, SPACE_HOMOGLYPHS, LATIN_CONFUSABLES };
+  const api = { clean, inspect, decide, isGlue, charLabel, isNoncharacter, isReservedIgnorable,
+    STRIP_CODEPOINTS, SPACE_HOMOGLYPHS, LATIN_CONFUSABLES };
   root.LayerA = api;
   if (typeof module !== "undefined" && module.exports) module.exports = api;
 })(typeof globalThis !== "undefined" ? globalThis : this);

--- a/scripts/upstream-sources.json
+++ b/scripts/upstream-sources.json
@@ -6,7 +6,7 @@
       "id": "watermarks-remover/service/scripts/text_unicode.py",
       "url": "https://raw.githubusercontent.com/guillaumemeyer/watermarks-remover/main/service/scripts/text_unicode.py",
       "history": "https://github.com/guillaumemeyer/watermarks-remover/commits/main/service/scripts/text_unicode.py",
-      "sha256": "cd21c5700184a6bb4a43089f546531a2692bf140413954ea9b93f4a67f1f3a5e",
+      "sha256": "ab0197b06263ad83a489032be69103e9a8725c72ddc3cf002a260c87b02647ac",
       "mirrors": [
         "js/layer_a.js",
         "tests/test_layer_a_parity.py"
@@ -16,11 +16,12 @@
       "id": "watermarks-remover/service/scripts/image_meta.py",
       "url": "https://raw.githubusercontent.com/guillaumemeyer/watermarks-remover/main/service/scripts/image_meta.py",
       "history": "https://github.com/guillaumemeyer/watermarks-remover/commits/main/service/scripts/image_meta.py",
-      "sha256": "422dbbea5eff172b78a6f38ade753d11857d62ff4811b97084000062c5622e4a",
+      "sha256": "78e5a67db243a4eac2a97b97cea036faae448bdaa2d77c59182af2c972657794",
       "mirrors": [
         "js/image_meta.js",
         "tests/test_image_meta_parity.py"
-      ]
+      ],
+      "comment": "Deliberately partial: upstream #156 hardened the error handling around the external c2patool subprocess (a failed run is inconclusive, not 'no C2PA'). There is no c2patool and no run_optional_tools in a browser, so js/image_meta.js has nothing to mirror there. Everything else in this file is ported."
     },
     {
       "id": "watermarks-remover/service/scripts/score_stylometry.py",

--- a/tests/test_image_meta_parity.py
+++ b/tests/test_image_meta_parity.py
@@ -86,6 +86,27 @@ def make_isobmff(brand: bytes, boxes: list[tuple[bytes, bytes]]) -> bytes:
     return ftyp + b"".join(iso_box(f, p) for f, p in boxes) + iso_box(b"mdat", b"\x00" * 8)
 
 
+def truncate_isobmff(data: bytes, cut: int) -> bytes:
+    """Drop the last `cut` bytes, so the final box overruns the buffer.
+
+    Upstream #170: the rebuild used to emit only the boxes that parsed, which
+    threw away a half-written mdat (the coded image) while reporting the file
+    as already clean.
+    """
+    return data[:-cut]
+
+
+def make_truncated_png(extra: list[tuple[bytes, bytes]], tail: bytes) -> bytes:
+    """A PNG cut mid-IDAT, with no IEND: the last chunk header declares more
+    payload than the file actually holds. Built without make_png because both
+    engines stop walking at IEND, so a tail appended after one is never seen.
+    """
+    body = image_meta.PNG_SIG + png_chunk(b"IHDR", struct.pack(">IIBBBBB", 1, 1, 8, 6, 0, 0, 0))
+    for t, payload in extra:
+        body += png_chunk(t, payload)
+    return body + struct.pack(">I", 4096) + b"IDAT" + tail
+
+
 
 # --- BMP / GIF / TIFF builders, mirroring upstream tests/test_image_formats_bmp_gif_tiff.py ---
 
@@ -255,6 +276,12 @@ SAMPLES = {
         ])),
     ]),
     "heic_c2pa_box": make_isobmff(b"heix", [(b"c2pa", JUMBF), (b"meta", iso_meta([(b"hdlr", b"\x00" * 12 + b"pict")]))]),
+    # Upstream #182: an interrupted download leaves a box (or a PNG chunk)
+    # whose declared length overruns the file. The tail has to survive.
+    "avif_truncated_tail": truncate_isobmff(
+        make_isobmff(b"avif", [(b"uuid", XMP_UUID + XMP_AI), (b"meta", iso_meta([(b"hdlr", b"\x00" * 12 + b"pict")]))]), 4),
+    "avif_truncated_junk": make_isobmff(b"avif", [(b"c2pa", JUMBF)]) + b"\x00\x01\x02",
+    "png_truncated_tail": make_truncated_png([(b"tEXt", b"Software\x00ChatGPT")], b"\x01\x02\x03\x04\x05\x06"),
     "bmp_clean": make_bmp(),
     "bmp_trailing_ai": make_bmp(b"digitalSourceType=trainedAlgorithmicMedia"),
     "bmp_trailing_plain": make_bmp(b"harmless scanner note"),
@@ -344,6 +371,39 @@ def test_idempotent_and_valid_structure() -> None:
         assert fmt == image_meta.detect_format(data)
         if fmt == "webp":
             assert struct.unpack("<I", once[4:8])[0] + 8 == len(once)
+
+
+def test_isobmff_unparsable_still_byte_scans() -> None:
+    """Upstream #176: when no box parses, the whole-file C2PA scan still runs.
+
+    strip_isobmff refuses this input on both sides, so it cannot live in SAMPLES
+    (which every clean-parity case must survive); inspect is the interesting half.
+    """
+    head = iso_box(b"ftyp", b"avif\x00\x00\x00\x00avifmif1")
+    # Overstate the very first box's size so the walk stops before box one.
+    broken = struct.pack(">I", 1 << 20) + head[4:] + JUMBF
+    assert image_meta.detect_format(broken) == "avif"
+    py = image_meta.inspect_isobmff(broken, "avif")
+    js = _js("inspect", broken, {})
+    assert (js["has_c2pa"], js["has_ai_metadata"], js["findings"]) == py
+    assert py[0] is True and any("byte-scan" in f for f in py[2])
+
+
+def test_isobmff_free_box_preserves_offsets() -> None:
+    """Upstream #183: a dropped box becomes an equal-size `free` box.
+
+    That is what keeps every absolute offset later in the file valid, so the
+    cleaned image is the same length and mdat has not moved.
+    """
+    for name in ("avif_xmp_c2pa", "heic_c2pa_box", "heic_meta", "avif_uuid_plain"):
+        src = SAMPLES[name]
+        out = base64.b64decode(_js("clean", src, {})["data"])
+        assert len(out) == len(src), name
+        assert out.index(b"mdat") == src.index(b"mdat"), name
+        assert b"free" in out, name
+        for secret in (XMP_AI, JUMBF, b"harmless camera note"):
+            if secret in src:
+                assert secret not in out, (name, secret)
 
 
 def test_bmp_and_tiff_structural_invariants() -> None:

--- a/tests/test_layer_a_parity.py
+++ b/tests/test_layer_a_parity.py
@@ -43,6 +43,17 @@ CASES = [
     "other cf: \U0001BCA0 shorthand, \U00013430 egyptian,   not cf",
     "nfkc: ＡＢ 　 ① ﬁ",
     "mixed ​😀️‍💩​ end \U0001F3F4\U000E0067 stray\U000E0067",
+    # upstream #133: late-assigned carriers, noncharacters, reserved ignorables
+    # and visible-layout Cf controls. Each layout case pairs the control next to
+    # its own script (kept) with the same control adrift in Latin text (stripped),
+    # so one case exercises both branches.
+    "mongolian fvs4 \u1820\u180f ok, stray \u180f",
+    "hangul filler \u3131\u3164 ok, stray \u3164; halfwidth \uffa1\uffa0 ok, stray \uffa0",
+    "noncharacters \ufdd0 \ufffe \U0001FFFF end",
+    "reserved ignorable \u2065 \ufff0 \U000E0000 \U000E0080 \U000E01F0 end",
+    "egyptian \U00013000\U00013430\U00013001 vs floating \U00013430 here",
+    "duployan \U0001BC00\U0001BCA0\U0001BC01 vs floating \U0001BCA0 here",
+    "musical \U0001D100\U0001D173\U0001D101 vs floating \U0001D173 here",
 ]
 
 OPTION_SETS = [


### PR DESCRIPTION
Closes #5.

Upstream `guillaumemeyer/watermarks-remover` moved twice since v0.2.0 and the daily drift check caught both. Before this change the parity suite was **7 failed / 384 passed** against upstream `main`; it is now **391 passed**.

## Layer A (upstream #133)

- `U+180F` (Mongolian FVS4, assigned in Unicode 14), `U+3164` (Hangul filler) and `U+FFA0` (halfwidth Hangul filler) join the strip set and their script-glue sets, so each one is preserved next to its own script and stripped when it floats.
- Unicode noncharacters (`U+FDD0..U+FDEF`, `U+nFFFE`, `U+nFFFF`) and reserved default-ignorables become strip-class, with `noncharacter` and `reserved_ignorable` inspect kinds. `js/detectors.js` already listed both kinds, so the Inspector picks them up with no change.
- Visible-layout format controls are kept when adjacent to their own script: Egyptian hieroglyph quadrat controls, Duployan shorthand overlap/step controls, musical beam/tie/slur/phrase controls. Next to that script they are document body, not carriers.

The reserved ranges are written out literally rather than derived from a `\p{Cn}` test, matching upstream's reasoning: the Unicode version behind that test moves with the engine, so a category rule would destroy freshly assigned real characters.

## Image containers (upstream #176, #182, #183)

- A dropped ISOBMFF box is overwritten with an equal-size `free` box instead of being spliced out, so absolute media offsets later in the file stay valid. Consequence worth knowing: a cleaned AVIF or HEIC now has the same length as the input. The metadata is still gone, the `free` payload is zeroed.
- `parseIsobmffBoxes` reports where the walk stopped, and both `stripIsobmff` and `stripPng` copy a truncated tail through verbatim rather than dropping it while reporting the file as already clean.
- `inspectIsobmff` runs the whole-file C2PA byte scan even when no box parses, which is exactly the case where it matters most.
- `inspectPng`'s truncated-chunk finding now carries the `b'...'` wrapper upstream produces, since the parity suite compares those strings.

## Not mirrored

Upstream #156 hardens error handling around the external `c2patool` subprocess. There is no `c2patool` and no `run_optional_tools` in a browser. Recorded in `scripts/upstream-sources.json` so the gap reads as a decision, not an oversight.

## Verification

```
WATERMARKS_UPSTREAM_DIR=<upstream main checkout> python -m pytest tests/ -q
391 passed
node scripts/check-upstream.mjs   # all 3 sources match
```

New fixtures cover every rule above: the late-assigned carriers, noncharacters, reserved ignorables, the layout controls both next to their script and adrift in Latin text, a truncated AVIF, a truncated PNG, trailing junk under 8 bytes, and an ISOBMFF whose first box header is unparsable. Two structural tests were added that byte parity cannot express: cleaned AVIF/HEIC keep their length with `mdat` unmoved and the secrets gone, and the unparsable container still reports its byte-scan hit.