### PR TITLE
Add a changelog to both READMEs, through v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Independent, browser-first web client for **[guillaumemeyer/watermarks-remover](
 
 - **Runs entirely in the browser** for text (Layer A: invisible Unicode / homoglyph spaces) and PNG / JPEG / WebP / AVIF / HEIC / BMP / GIF / TIFF metadata (C2PA, EXIF, XMP, text chunks). No uploads, no analytics, no web fonts, no third-party requests.
 - **Optionally drives the upstream Python service** (`server.py`) for everything else — PDF, DOCX, ODT, EPUB, full HTML/SVG/Markdown container cleaning, and pixel-domain backends.
-- The JavaScript engines are **line-for-line ports of upstream's `text_unicode.py`, `image_meta.py` and `score_stylometry.py`**, and a parity test suite asserts identical output (same characters kept/stripped, same bytes out of the image parsers, same stylometry numbers).
-- A **Watermark Inspector** tab runs every detector on one input and reports each separately — character layer, metadata layer, statistical layer — and can re-run them after a Layer A clean to show what the cleaner did *not* touch. Statistical detectors (Kirchenbauer, SynthID-Text) run through an optional local sidecar.
+- The JavaScript engines are **line-for-line ports of upstream's `text_unicode.py`, `image_meta.py`, `score_stylometry.py` and `detect_gumbel.py`**, and a parity test suite asserts identical output (same characters kept/stripped, same bytes out of the image parsers, same stylometry numbers, same keyed-Gumbel p-value).
+- A **Watermark Inspector** tab runs every detector on one input and reports each separately — character layer, metadata layer, statistical layer — and can re-run them after a Layer A clean to show what the cleaner did *not* touch. Keyed-Gumbel (EXP) detection runs in the page itself; the other statistical detectors (Kirchenbauer, SynthID-Text) run through an optional local sidecar.
 
 Live demo: [https://ivanusto.github.io/unmark-web/](https://ivanusto.github.io/unmark-web/) · Local: open `index.html` or run `python3 serve_local.py`.
 
@@ -160,15 +160,38 @@ There is no `package.json` here — nothing at runtime or in the test suite need
 - `js/layer_a.js` — port of `text_unicode.py` (`clean`, `inspect`, `decide`)
 - `js/image_meta.js` — port of `image_meta.py` (PNG/JPEG/WebP/AVIF/HEIC/BMP/GIF/TIFF inspect + strip)
 - `js/stylometry.js` — port of `score_stylometry.py` (burstiness / MATTR / AI-phrase density; heuristic, not a watermark detector)
+- `js/gumbel.js`: port of `detect_gumbel.py` (keyed-Gumbel / EXP same-key replay, with its own synchronous SHA-256 and HMAC so it needs neither `crypto.subtle` nor a secure context)
 - `js/detectors.js` — the Inspector's detector registry: one result contract for the character, metadata and statistical layers, plus `summarize()` / `compare()` for the Overall box and the before/after view
 - `js/api.js` — client for `/health /capabilities /inspect /clean /detect`, plus the optional `/llm-config` + `/llm` rewrite calls and `/stat-config` + `/stat` sidecar calls
 - `js/i18n.js`, `js/app.js`, `css/app.css`, `index.html` — UI (English / 繁體中文 / 简体中文, light/dark, keyboard-accessible). The locale is picked from `navigator.languages` and remembered in `localStorage`; adding a language is one entry in `LANGS` plus one dictionary in `js/i18n.js`.
-- `tests/test_layer_a_parity.py`, `tests/test_image_meta_parity.py`, `tests/test_stylometry_parity.py` — cross-engine parity vs the upstream checkout (skipped if `node` or the checkout is missing)
+- `tests/test_layer_a_parity.py`, `tests/test_image_meta_parity.py`, `tests/test_stylometry_parity.py`, `tests/test_gumbel_parity.py` — cross-engine parity vs the upstream checkout (skipped if `node` or the checkout is missing)
+- `tests/test_i18n_keys.py`: every locale carries every key, and every `data-i18n` attribute in `index.html` resolves. A gap there is invisible at runtime, because `t()` falls back silently.
 - `serve_local.py` — same-origin static + `/api` proxy, the optional `/llm` rewrite proxy and the optional `/stat` sidecar proxy
 - `sidecar/` — the statistical-detector sidecar (its own `requirements.txt`; never part of the page)
 - `scripts/check-upstream.mjs` — run it with `node scripts/check-upstream.mjs`; hashes the upstream Python modules against `scripts/upstream-sources.json`; `.github/workflows/upstream-check.yml` runs it and the parity suite daily and files an issue when either signal fires. Parity catches behaviour that changed; the hashes catch changes the fixtures do not reach, such as a newly supported format.
 
 No build step, no dependencies at runtime. CSP: `default-src 'self'; connect-src *` (the latter so you can point at your own server).
+
+## Changelog
+
+Full notes on each [release](https://github.com/ivanusto/unmark-web/releases).
+
+### [v0.3.0](https://github.com/ivanusto/unmark-web/releases/tag/v0.3.0)
+
+- **Keyed-Gumbel (EXP) detection in the browser** (`js/gumbel.js`, port of upstream's `detect_gumbel.py`). The first statistical detector that needs no sidecar, no model weights and no network, so it reaches a verdict on the hosted page. It is a same-key replay: `clean` means *not this key*, never *no watermark*.
+- **Layer A hardening** (upstream #133): `U+180F`, `U+3164` and `U+FFA0` are kept next to their own script and stripped when they float; Unicode noncharacters and reserved default-ignorables are now strip-class; visible-layout format controls (Egyptian quadrat, Duployan, musical beaming) are kept next to their own script.
+- **Image containers** (upstream #176, #182, #183): a dropped ISOBMFF box is overwritten with an equal-size `free` box, so a cleaned AVIF or HEIC keeps its length and later media offsets stay valid; a truncated PNG chunk or ISOBMFF box keeps its tail instead of being dropped while the run claims the file was already clean.
+- Parity anchors moved to `text_unicode.py` `ab0197b06263`, `image_meta.py` `78e5a67db243`, and the new `detect_gumbel.py` `f908272084cd`.
+
+### [v0.2.0](https://github.com/ivanusto/unmark-web/releases/tag/v0.2.0)
+
+- **Watermark Inspector**: a third tab that runs every detector on one input and reports each separately across the character, metadata and statistical layers, through one result contract (`js/detectors.js`).
+- **Stylometry** (`js/stylometry.js`, port of `score_stylometry.py`), capped at *uncertain* because a heuristic is not a watermark detector.
+- **Statistical sidecar** (`sidecar/unmark_stat.py`): Kirchenbauer/KGW and SynthID-Text detection with the reference `transformers` detectors, proxied same-origin by `serve_local.py --stat-upstream`. Local only, off by default.
+
+### [v0.1.0](https://github.com/ivanusto/unmark-web/releases/tag/v0.1.0)
+
+First release. Layer A text cleaning and image container cleaning in the browser, three locales, an optional local AI rewrite behind `serve_local.py`, and the parity suite that pins both engines to upstream.
 
 ## Attribution & license
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -8,8 +8,8 @@
 
 - **完全在瀏覽器中執行**：文字（Layer A：隱形 Unicode／同形字空白）與 PNG／JPEG／WebP／AVIF／HEIC／BMP／GIF／TIFF 中繼資料（C2PA、EXIF、XMP、文字區塊）皆是。不上傳、不做分析追蹤、不載入網頁字型、不發送任何第三方請求。
 - **可選擇驅動上游的 Python 服務**（`server.py`）處理其餘格式，PDF、DOCX、ODT、EPUB、完整的 HTML／SVG／Markdown 容器清理，以及像素域後端。
-- JavaScript 引擎是上游 **`text_unicode.py`、`image_meta.py` 與 `score_stylometry.py` 的逐行移植**，並有一套 parity 測試驗證輸出完全一致（保留／移除的字元相同，圖片解析器輸出的位元組相同，文風統計的數字也相同）。
-- **「檢測器」分頁**是一個偵測實驗室：對同一份輸入跑過每一個偵測器並分別回報，字元層、中繼資料層、統計層，還能在 Layer A 清理後重新檢測，讓你看清楚清理器*沒有*動到哪一層。統計型偵測器（Kirchenbauer、SynthID-Text）透過選用的本機 sidecar 執行。
+- JavaScript 引擎是上游 **`text_unicode.py`、`image_meta.py`、`score_stylometry.py` 與 `detect_gumbel.py` 的逐行移植**，並有一套 parity 測試驗證輸出完全一致（保留／移除的字元相同，圖片解析器輸出的位元組相同，文風統計的數字相同，keyed-Gumbel 的 p 值也相同）。
+- **「檢測器」分頁**是一個偵測實驗室：對同一份輸入跑過每一個偵測器並分別回報，字元層、中繼資料層、統計層，還能在 Layer A 清理後重新檢測，讓你看清楚清理器*沒有*動到哪一層。Keyed-Gumbel（EXP）偵測直接在頁面裡跑；其餘統計型偵測器（Kirchenbauer、SynthID-Text）透過選用的本機 sidecar 執行。
 
 線上示範：[https://ivanusto.github.io/unmark-web/](https://ivanusto.github.io/unmark-web/) · 本機執行：直接開啟 `index.html`，或執行 `python3 serve_local.py`。
 
@@ -158,15 +158,38 @@ node scripts/check-upstream.mjs                                                 
 - `js/layer_a.js`，`text_unicode.py` 的移植（`clean`、`inspect`、`decide`）
 - `js/image_meta.js`，`image_meta.py` 的移植（PNG/JPEG/WebP/AVIF/HEIC/BMP/GIF/TIFF 檢查與清除）
 - `js/stylometry.js`，`score_stylometry.py` 的移植（burstiness／MATTR／AI 片語密度；啟發式，不是浮水印偵測器）
+- `js/gumbel.js`，`detect_gumbel.py` 的移植（keyed-Gumbel／EXP 同金鑰重放，自帶同步版 SHA-256 與 HMAC，因此不需要 `crypto.subtle`，也不需要 secure context）
 - `js/detectors.js`，檢測器的偵測器註冊表：字元、中繼資料、統計三層共用一種結果契約，加上給總結與前後對照用的 `summarize()`／`compare()`
 - `js/api.js`，`/health /capabilities /inspect /clean /detect` 的客戶端，以及選用的 `/llm-config`＋`/llm` 改寫呼叫與 `/stat-config`＋`/stat` sidecar 呼叫
 - `js/i18n.js`、`js/app.js`、`css/app.css`、`index.html`，UI（英文／繁體中文／簡體中文、淺色／深色、支援鍵盤操作）。語系依 `navigator.languages` 判斷並記在 `localStorage`；新增語言只需在 `js/i18n.js` 的 `LANGS` 加一列、再加一本字典。
-- `tests/test_layer_a_parity.py`、`tests/test_image_meta_parity.py`、`tests/test_stylometry_parity.py`，與上游 checkout 的跨引擎 parity 測試（缺少 `node` 或該 checkout 時會跳過）
+- `tests/test_layer_a_parity.py`、`tests/test_image_meta_parity.py`、`tests/test_stylometry_parity.py`、`tests/test_gumbel_parity.py`，與上游 checkout 的跨引擎 parity 測試（缺少 `node` 或該 checkout 時會跳過）
+- `tests/test_i18n_keys.py`，三個語系必須有相同的字串鍵，且 `index.html` 裡每個 `data-i18n` 都解得開。這種缺口在執行期看不出來，因為 `t()` 會靜靜 fallback。
 - `serve_local.py`，同源靜態伺服器 + `/api` 代理、選用的 `/llm` 改寫代理，以及選用的 `/stat` sidecar 代理
 - `sidecar/`，統計型偵測器 sidecar（有自己的 `requirements.txt`；永遠不是頁面的一部分）
 - `scripts/check-upstream.mjs`，以 `node scripts/check-upstream.mjs` 執行；以 `scripts/upstream-sources.json` 記錄的雜湊比對上游 Python 模組；`.github/workflows/upstream-check.yml` 每天執行它與 parity 測試，任一訊號觸發就開 issue。parity 抓行為改變，雜湊抓測試涵蓋不到的變動（例如上游新增了一種格式）。
 
 沒有建置步驟，執行期零相依。CSP：`default-src 'self'; connect-src *`（後者是為了讓你能指向自己的伺服器）。
+
+## 版本紀錄
+
+各版完整說明見 [releases](https://github.com/ivanusto/unmark-web/releases)。
+
+### [v0.3.0](https://github.com/ivanusto/unmark-web/releases/tag/v0.3.0)
+
+- **瀏覽器端的 Keyed-Gumbel（EXP）偵測**（`js/gumbel.js`，移植自上游 `detect_gumbel.py`）。第一個不需要 sidecar、不需要模型權重、也不需要連外的統計型偵測器，所以線上版也能得出判定。它是同金鑰重放：判定為「乾淨」的意思是*不是這把金鑰*，不是*沒有浮水印*。
+- **Layer A 強化**（上游 #133）：`U+180F`、`U+3164`、`U+FFA0` 緊鄰自身書寫系統時保留、漂浮時移除；Unicode 非字元與保留的預設可忽略字元改為移除類；緊鄰自身書寫系統的排版控制字元（埃及聖書體象限、Duployan 速記、音樂符號連桿）予以保留。
+- **圖片容器**（上游 #176、#182、#183）：被移除的 ISOBMFF 盒改成就地覆寫為等長的 `free` 盒，因此清理後的 AVIF／HEIC 大小不變，檔案後段的媒體 offset 也仍然有效；被截斷的 PNG chunk 或 ISOBMFF 盒會保留尾段，不再一邊丟掉一邊宣稱檔案本來就是乾淨的。
+- Parity 錨點更新為 `text_unicode.py` `ab0197b06263`、`image_meta.py` `78e5a67db243`，以及新增的 `detect_gumbel.py` `f908272084cd`。
+
+### [v0.2.0](https://github.com/ivanusto/unmark-web/releases/tag/v0.2.0)
+
+- **檢測器（Watermark Inspector）**：第三個分頁，對同一份輸入跑過每個偵測器並分別回報，涵蓋字元、中繼資料、統計三層，共用同一種結果契約（`js/detectors.js`）。
+- **文風統計**（`js/stylometry.js`，移植自 `score_stylometry.py`），上限是「不確定」，因為啟發式不是浮水印偵測器。
+- **統計層 sidecar**（`sidecar/unmark_stat.py`）：以 `transformers` 內建的參考偵測器做 Kirchenbauer／KGW 與 SynthID-Text 偵測，由 `serve_local.py --stat-upstream` 同源代理。僅限本機，預設關閉。
+
+### [v0.1.0](https://github.com/ivanusto/unmark-web/releases/tag/v0.1.0)
+
+首個版本。瀏覽器端的 Layer A 文字清理與圖片容器清理、三個語系、`serve_local.py` 後面選用的本機 AI 改寫，以及把兩支引擎釘在上游的 parity 測試。
 
 ## 致謝與授權
 


### PR DESCRIPTION
Neither README had a changelog, so the only record of what changed between versions lived on the releases page. This adds one to both, three entries newest first, each heading linking to its full release notes.

Two things the READMEs had drifted on, fixed while here:

- The intro bullet still called the JavaScript engines line-for-line ports of three Python modules. There are four now, and the parity suite pins the keyed-Gumbel p-value as well.
- The Development file list was missing `js/gumbel.js`, `tests/test_gumbel_parity.py` and `tests/test_i18n_keys.py`.

Both files keep the same section structure, so the two languages stay navigable side by side. All three release links resolve.