### PR TITLE
Drop the em dashes from both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 > Renamed from `watermarks-remover-web` in August 2026, at the upstream maintainer's request, so it isn't mistaken for an official component. GitHub redirects the old repository URL; the demo moved to the address below.
 
-Independent, browser-first web client for **[guillaumemeyer/watermarks-remover](https://github.com/guillaumemeyer/watermarks-remover)** — inspired by and compatible with its HTTP API. Not affiliated with the upstream project.
+Independent, browser-first web client for **[guillaumemeyer/watermarks-remover](https://github.com/guillaumemeyer/watermarks-remover)**, inspired by and compatible with its HTTP API. Not affiliated with the upstream project.
 
 - **Runs entirely in the browser** for text (Layer A: invisible Unicode / homoglyph spaces) and PNG / JPEG / WebP / AVIF / HEIC / BMP / GIF / TIFF metadata (C2PA, EXIF, XMP, text chunks). No uploads, no analytics, no web fonts, no third-party requests.
-- **Optionally drives the upstream Python service** (`server.py`) for everything else — PDF, DOCX, ODT, EPUB, full HTML/SVG/Markdown container cleaning, and pixel-domain backends.
+- **Optionally drives the upstream Python service** (`server.py`) for everything else: PDF, DOCX, ODT, EPUB, full HTML/SVG/Markdown container cleaning, and pixel-domain backends.
 - The JavaScript engines are **line-for-line ports of upstream's `text_unicode.py`, `image_meta.py`, `score_stylometry.py` and `detect_gumbel.py`**, and a parity test suite asserts identical output (same characters kept/stripped, same bytes out of the image parsers, same stylometry numbers, same keyed-Gumbel p-value).
-- A **Watermark Inspector** tab runs every detector on one input and reports each separately — character layer, metadata layer, statistical layer — and can re-run them after a Layer A clean to show what the cleaner did *not* touch. Keyed-Gumbel (EXP) detection runs in the page itself; the other statistical detectors (Kirchenbauer, SynthID-Text) run through an optional local sidecar.
+- A **Watermark Inspector** tab runs every detector on one input and reports each separately across the character, metadata and statistical layers, and can re-run them after a Layer A clean to show what the cleaner did *not* touch. Keyed-Gumbel (EXP) detection runs in the page itself; the other statistical detectors (Kirchenbauer, SynthID-Text) run through an optional local sidecar.
 
 Live demo: [https://ivanusto.github.io/unmark-web/](https://ivanusto.github.io/unmark-web/) · Local: open `index.html` or run `python3 serve_local.py`.
 
@@ -23,11 +23,11 @@ Live demo: [https://ivanusto.github.io/unmark-web/](https://ivanusto.github.io/u
 | Input | Browser engine | Server engine (`server.py`) |
 | --- | --- | --- |
 | Pasted text / `.txt` | Layer A: zero-width & bidi controls, variation selectors, tag chars, PUA, Unicode noncharacters, reserved default-ignorables, other `Cf`; space homoglyphs; optional NFKC / Latin confusables. Preserves load-bearing invisibles (emoji ZWJ/VS16, Persian/Indic ZWNJ, flag tags, Mongolian FVS, Khmer vowels, Hangul fillers, Arabic Cf, and layout format controls next to their own script: Egyptian quadrat, Duployan, musical beaming) exactly like upstream, with a "paranoid" toggle. | same |
-| `.md` `.html` `.svg` | Layer A on the text only (metadata tags/frontmatter untouched — flagged in the UI) | full container cleaning (frontmatter keys, `<meta generator>`, XMP, …) |
+| `.md` `.html` `.svg` | Layer A on the text only (metadata tags/frontmatter untouched, which the UI flags) | full container cleaning (frontmatter keys, `<meta generator>`, XMP, …) |
 | PNG / JPEG / WebP / AVIF / HEIC | drops `tEXt/zTXt/iTXt/eXIf/caBX/c2*` chunks, `APPn` (except JFIF) + `COM` segments, `EXIF/XMP/ICCP/C2PA` RIFF chunks with VP8X flag fix-up, and `jumb/c2pa/uuid` (XMP) ISOBMFF boxes plus their `meta` sub-boxes. Pixels are untouched (no canvas re-encode). "Keep non-AI metadata" mode only drops blocks with AI/C2PA hints. | same, plus optional pixel-domain backends if installed |
 | BMP / GIF / TIFF | BMP: drops the trailing bytes after the pixel payload (the only place BMP metadata can live) and rewrites the file-size field. GIF: drops comment and XMP/unknown application extensions, keeping NETSCAPE2.0 looping and ICC. TIFF (classic and BigTIFF): walks the IFD chains and drops XMP/EXIF/GPS/IPTC/Photoshop/MakerNote tags, patching each IFD in place so strip and tile offsets stay valid. | same |
-| PDF / DOCX / ODT / EPUB | — (needs server) | yes |
-| Statistical text watermarks (Kirchenbauer / KGW, SynthID-Text) | **detect only**, via the optional local [sidecar](sidecar/README.md) (needs a model and the generator's key); never removed — see upstream Layer B for rewriting | via upstream `/detect` (MarkLLM harness) when the server advertises text detectors |
+| PDF / DOCX / ODT / EPUB | no (needs server) | yes |
+| Statistical text watermarks (Kirchenbauer / KGW, SynthID-Text) | **detect only**, via the optional local [sidecar](sidecar/README.md) (needs a model and the generator's key); never removed, see upstream Layer B for rewriting | via upstream `/detect` (MarkLLM harness) when the server advertises text detectors |
 | Pixel watermarks (SynthID image, …) | **no** | via upstream backends only |
 
 Two consequences of the container rules that surprise people:
@@ -43,9 +43,9 @@ Two consequences of the container rules that surprise people:
 
 ## Connecting a server
 
-`server.py` binds to `127.0.0.1:8765`, sends **no CORS headers**, and may require a bearer token — by design. Three ways to use it from this UI:
+`server.py` binds to `127.0.0.1:8765`, sends **no CORS headers**, and may require a bearer token, all by design. Three ways to use it from this UI:
 
-1. **`serve_local.py` (recommended)** — stdlib, loopback-only static server that proxies `/api/*` to `server.py`, so the browser talks same-origin:
+1. **`serve_local.py` (recommended)**: stdlib, loopback-only static server that proxies `/api/*` to `server.py`, so the browser talks same-origin:
    ```bash
    # terminal 1: upstream service
    python3 service/scripts/server.py                     # from the upstream checkout (or its Docker image)
@@ -54,13 +54,13 @@ Two consequences of the container rules that surprise people:
    # open http://127.0.0.1:8766/  → the UI auto-selects /api
    ```
 2. **Any reverse proxy** that serves this directory and forwards a path to `server.py`; enter that path (e.g. `/api`) or URL in ⚙️ *Server connection*.
-3. **Direct URL** (e.g. from the GitHub Pages build) — only works if something in front of the server allows this page's origin via CORS. Upstream deliberately ships **no** CORS support in `server.py` (the API is meant to be server-to-server; see [issue #77](https://github.com/guillaumemeyer/watermarks-remover/issues/77) and [PR #78](https://github.com/guillaumemeyer/watermarks-remover/pull/78)), so this means your own reverse proxy in front of it. Do **not** put a wildcard CORS header on the API.
+3. **Direct URL** (e.g. from the GitHub Pages build), which only works if something in front of the server allows this page's origin via CORS. Upstream deliberately ships **no** CORS support in `server.py` (the API is meant to be server-to-server; see [issue #77](https://github.com/guillaumemeyer/watermarks-remover/issues/77) and [PR #78](https://github.com/guillaumemeyer/watermarks-remover/pull/78)), so this means your own reverse proxy in front of it. Do **not** put a wildcard CORS header on the API.
 
 The API key is only sent as `Authorization: Bearer …` to the URL you configured, and only stored in `localStorage` if you tick *Remember in this browser*.
 
 ## AI rewrite (optional, local only)
 
-Cleaning strips the marks; it does not touch the prose. If you also want the text rewritten out of its AI cadence, `serve_local.py` can proxy an **OpenAI-compatible chat endpoint of your own** — a local model runner, or anything else you host:
+Cleaning strips the marks; it does not touch the prose. If you also want the text rewritten out of its AI cadence, `serve_local.py` can proxy an **OpenAI-compatible chat endpoint of your own**: a local model runner, or anything else you host:
 
 ```bash
 # --llm-upstream  base URL, without the /v1 suffix
@@ -89,7 +89,7 @@ The *Inspector* tab is a detection lab, deliberately separated from the cleaners
 
 | Layer | Detectors | Where it runs | What a hit means |
 | --- | --- | --- | --- |
-| **Character** | invisible / format Unicode, bidi controls, homoglyphs & exotic spaces | browser (`js/layer_a.js`) | deterministic — Layer A can strip it, and re-inspecting proves it |
+| **Character** | invisible / format Unicode, bidi controls, homoglyphs & exotic spaces | browser (`js/layer_a.js`) | deterministic: Layer A can strip it, and re-inspecting proves it |
 | **Metadata** | C2PA / Content Credentials, XMP, EXIF / TIFF tags, AI-generator markers, other | browser (`js/image_meta.js`) | provenance or generator metadata is present in the container |
 | **Statistical** | keyed-Gumbel / EXP, Kirchenbauer (KGW green-list), SynthID-Text, upstream `/detect`, TextSeal (placeholder), stylometry (heuristic) | browser (`js/gumbel.js`) / local sidecar / upstream server | the token sequence carries a sampling watermark **for the key you tested**, nothing more |
 
@@ -107,8 +107,8 @@ Every detector returns the same shape, and *Copy JSON report* exports exactly th
 Three rules the UI enforces, because honesty is the feature:
 
 - **Detector and cleaner are separate.** *Clean (Layer A) & re-inspect* runs the cleaner once and shows every detector before / after with a *changed?* column. When the statistical rows come back identical, the Overall box says so: *Layer A cleaning did not affect the statistical watermark detectors.*
-- **A heuristic can never say "detected".** Stylometry (burstiness, MATTR, AI-phrase density — upstream's `score_stylometry.py`, ported) is capped at *uncertain* and labelled *heuristic* on the row.
-- **"Unavailable" is not "clean".** Most statistical detectors need the generator's key, tokenizer and a model. On the hosted HTTPS page those report *unavailable* and the Overall line reads *Statistical watermarks were not tested here — they cannot be ruled out.* A *clean* is likewise scoped to the key and scheme you tested.
+- **A heuristic can never say "detected".** Stylometry (burstiness, MATTR, AI-phrase density, ported from upstream's `score_stylometry.py`) is capped at *uncertain* and labelled *heuristic* on the row.
+- **"Unavailable" is not "clean".** Most statistical detectors need the generator's key, tokenizer and a model. On the hosted HTTPS page those report *unavailable*, and the Overall line says statistical watermarks were not tested there and cannot be ruled out. A *clean* is likewise scoped to the key and scheme you tested.
 
 ### Keyed-Gumbel (EXP), in the browser
 
@@ -144,7 +144,7 @@ python3 serve_local.py --stat-upstream http://127.0.0.1:8767
 
 Then, in the Inspector: *Generate* with SynthID-Text and key **A** → *Inspect* with key A (detected) → switch to key **B** (clean / uncertain) → *Clean (Layer A) & re-inspect* (scores unchanged). Two worlds: the character layer goes to zero, the statistical layer does not move.
 
-Limits, stated plainly: detection is only valid for the **same scheme, the same key and the same tokenizer** as generation; text from a model whose keys you do not hold cannot be judged, and the sidecar says *clean for this key*, never *not watermarked*. Like the rewrite panel, it is a `serve_local.py` feature — the hosted page cannot reach a plain-HTTP loopback service.
+Limits, stated plainly: detection is only valid for the **same scheme, the same key and the same tokenizer** as generation; text from a model whose keys you do not hold cannot be judged, and the sidecar says *clean for this key*, never *not watermarked*. Like the rewrite panel, it is a `serve_local.py` feature, because the hosted page cannot reach a plain-HTTP loopback service.
 
 ## Development
 
@@ -155,20 +155,20 @@ WATERMARKS_UPSTREAM_DIR=../watermarks-remover .venv/bin/pytest -q
 node scripts/check-upstream.mjs                                                          # upstream hash drift
 ```
 
-There is no `package.json` here — nothing at runtime or in the test suite needs npm, so the upstream check runs straight through `node`, exactly as [the workflow](.github/workflows/upstream-check.yml) does. It exits `0` when the recorded hashes still match, `1` on drift, and `2` when it could not check at all (network, rate limit, bad manifest) — an unreachable source is never reported as drift.
+There is no `package.json` here, because nothing at runtime or in the test suite needs npm, so the upstream check runs straight through `node`, exactly as [the workflow](.github/workflows/upstream-check.yml) does. It exits `0` when the recorded hashes still match, `1` on drift, and `2` when it could not check at all (network, rate limit, bad manifest), so an unreachable source is never reported as drift.
 
-- `js/layer_a.js` — port of `text_unicode.py` (`clean`, `inspect`, `decide`)
-- `js/image_meta.js` — port of `image_meta.py` (PNG/JPEG/WebP/AVIF/HEIC/BMP/GIF/TIFF inspect + strip)
-- `js/stylometry.js` — port of `score_stylometry.py` (burstiness / MATTR / AI-phrase density; heuristic, not a watermark detector)
+- `js/layer_a.js`: port of `text_unicode.py` (`clean`, `inspect`, `decide`)
+- `js/image_meta.js`: port of `image_meta.py` (PNG/JPEG/WebP/AVIF/HEIC/BMP/GIF/TIFF inspect + strip)
+- `js/stylometry.js`: port of `score_stylometry.py` (burstiness / MATTR / AI-phrase density; heuristic, not a watermark detector)
 - `js/gumbel.js`: port of `detect_gumbel.py` (keyed-Gumbel / EXP same-key replay, with its own synchronous SHA-256 and HMAC so it needs neither `crypto.subtle` nor a secure context)
-- `js/detectors.js` — the Inspector's detector registry: one result contract for the character, metadata and statistical layers, plus `summarize()` / `compare()` for the Overall box and the before/after view
-- `js/api.js` — client for `/health /capabilities /inspect /clean /detect`, plus the optional `/llm-config` + `/llm` rewrite calls and `/stat-config` + `/stat` sidecar calls
-- `js/i18n.js`, `js/app.js`, `css/app.css`, `index.html` — UI (English / 繁體中文 / 简体中文, light/dark, keyboard-accessible). The locale is picked from `navigator.languages` and remembered in `localStorage`; adding a language is one entry in `LANGS` plus one dictionary in `js/i18n.js`.
-- `tests/test_layer_a_parity.py`, `tests/test_image_meta_parity.py`, `tests/test_stylometry_parity.py`, `tests/test_gumbel_parity.py` — cross-engine parity vs the upstream checkout (skipped if `node` or the checkout is missing)
+- `js/detectors.js`: the Inspector's detector registry: one result contract for the character, metadata and statistical layers, plus `summarize()` / `compare()` for the Overall box and the before/after view
+- `js/api.js`: client for `/health /capabilities /inspect /clean /detect`, plus the optional `/llm-config` + `/llm` rewrite calls and `/stat-config` + `/stat` sidecar calls
+- `js/i18n.js`, `js/app.js`, `css/app.css`, `index.html`: UI (English / 繁體中文 / 简体中文, light/dark, keyboard-accessible). The locale is picked from `navigator.languages` and remembered in `localStorage`; adding a language is one entry in `LANGS` plus one dictionary in `js/i18n.js`.
+- `tests/test_layer_a_parity.py`, `tests/test_image_meta_parity.py`, `tests/test_stylometry_parity.py`, `tests/test_gumbel_parity.py`: cross-engine parity vs the upstream checkout (skipped if `node` or the checkout is missing)
 - `tests/test_i18n_keys.py`: every locale carries every key, and every `data-i18n` attribute in `index.html` resolves. A gap there is invisible at runtime, because `t()` falls back silently.
-- `serve_local.py` — same-origin static + `/api` proxy, the optional `/llm` rewrite proxy and the optional `/stat` sidecar proxy
-- `sidecar/` — the statistical-detector sidecar (its own `requirements.txt`; never part of the page)
-- `scripts/check-upstream.mjs` — run it with `node scripts/check-upstream.mjs`; hashes the upstream Python modules against `scripts/upstream-sources.json`; `.github/workflows/upstream-check.yml` runs it and the parity suite daily and files an issue when either signal fires. Parity catches behaviour that changed; the hashes catch changes the fixtures do not reach, such as a newly supported format.
+- `serve_local.py`: same-origin static + `/api` proxy, the optional `/llm` rewrite proxy and the optional `/stat` sidecar proxy
+- `sidecar/`: the statistical-detector sidecar (its own `requirements.txt`; never part of the page)
+- `scripts/check-upstream.mjs`: run it with `node scripts/check-upstream.mjs`; hashes the upstream Python modules against `scripts/upstream-sources.json`; `.github/workflows/upstream-check.yml` runs it and the parity suite daily and files an issue when either signal fires. Parity catches behaviour that changed; the hashes catch changes the fixtures do not reach, such as a newly supported format.
 
 No build step, no dependencies at runtime. CSP: `default-src 'self'; connect-src *` (the latter so you can point at your own server).
 
@@ -195,4 +195,4 @@ First release. Layer A text cleaning and image container cleaning in the browser
 
 ## Attribution & license
 
-MIT — see [LICENSE](LICENSE). The character tables, decision rules and container parsers are derived from watermarks-remover, © watermarks-remover contributors, MIT; the upstream notice is preserved in [NOTICE](NOTICE). Use on content you own or are authorised to modify — see upstream's [ethics notes](https://github.com/guillaumemeyer/watermarks-remover/blob/main/skills/remove-ai-marks/references/ethics.md).
+MIT, see [LICENSE](LICENSE). The character tables, decision rules and container parsers are derived from watermarks-remover, © watermarks-remover contributors, MIT; the upstream notice is preserved in [NOTICE](NOTICE). Use on content you own or are authorised to modify; see upstream's [ethics notes](https://github.com/guillaumemeyer/watermarks-remover/blob/main/skills/remove-ai-marks/references/ethics.md).

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -52,7 +52,7 @@
    # 開啟 http://127.0.0.1:8766/  → UI 會自動選用 /api
    ```
 2. **任何 reverse proxy**：只要它能服務這個目錄，並把某個路徑轉發到 `server.py`；接著在 ⚙️ *伺服器連線* 中填入該路徑（例如 `/api`）或 URL。
-3. **直接填 URL**（例如從 GitHub Pages 版本使用）， 只有在伺服器前方有東西以 CORS 允許本頁的來源時才會成功。上游刻意在 `server.py` 中**不**提供 CORS 支援（該 API 的定位是伺服器對伺服器；參見 [issue #77](https://github.com/guillaumemeyer/watermarks-remover/issues/77) 與 [PR #78](https://github.com/guillaumemeyer/watermarks-remover/pull/78)），因此這代表你得自行在它前面架 reverse proxy。請**不要**在該 API 上掛萬用字元的 CORS 標頭。
+3. **直接填 URL**（例如從 GitHub Pages 版本使用）：只有在伺服器前方有東西以 CORS 允許本頁的來源時才會成功。上游刻意在 `server.py` 中**不**提供 CORS 支援（該 API 的定位是伺服器對伺服器；參見 [issue #77](https://github.com/guillaumemeyer/watermarks-remover/issues/77) 與 [PR #78](https://github.com/guillaumemeyer/watermarks-remover/pull/78)），因此這代表你得自行在它前面架 reverse proxy。請**不要**在該 API 上掛萬用字元的 CORS 標頭。
 
 API 金鑰只會以 `Authorization: Bearer …` 送往你所設定的 URL，而且只有在勾選 *記住於此瀏覽器* 時才會存入 `localStorage`。
 
@@ -153,7 +153,7 @@ WATERMARKS_UPSTREAM_DIR=../watermarks-remover .venv/bin/pytest -q
 node scripts/check-upstream.mjs                                                          # 檢查上游雜湊漂移
 ```
 
-本專案沒有 `package.json`，執行期與測試都不需要 npm，因此上游檢查直接用 `node` 執行，與 [workflow](.github/workflows/upstream-check.yml) 的呼叫方式完全一致。退出碼：`0` 表示雜湊仍相符、`1` 表示偵測到漂移、`2` 表示根本無法檢查（網路、速率限制、manifest 有問題）， 抓不到來源絕不會被當成漂移回報。
+本專案沒有 `package.json`，執行期與測試都不需要 npm，因此上游檢查直接用 `node` 執行，與 [workflow](.github/workflows/upstream-check.yml) 的呼叫方式完全一致。退出碼：`0` 表示雜湊仍相符、`1` 表示偵測到漂移、`2` 表示根本無法檢查（網路、速率限制、manifest 有問題）。抓不到來源絕不會被當成漂移回報。
 
 - `js/layer_a.js`，`text_unicode.py` 的移植（`clean`、`inspect`、`decide`）
 - `js/image_meta.js`，`image_meta.py` 的移植（PNG/JPEG/WebP/AVIF/HEIC/BMP/GIF/TIFF 檢查與清除）


### PR DESCRIPTION
All 29 em dashes in `README.md` are gone. Every one is rewritten as a separate clause or a colon rather than having the character swapped for another symbol, because a straight substitution is what produced the damage described below.

Two needed more than punctuation:

- **The PDF / DOCX / ODT / EPUB table row used a bare em dash as a cell meaning "not supported".** That is content, not punctuation. It now reads `no (needs server)`, matching what the Chinese table already said.
- **The Inspector section quoted the Overall line verbatim, dash and all.** A quote that no longer matches the string it quotes is a worse problem than the dash, so that sentence is a paraphrase now and cannot drift from `js/i18n.js`.

`README.zh-TW.md` already had no dashes, but it carried two sentences that an earlier in-place swap had broken: the dash became a comma and the space around it stayed, leaving `）， 只有在…` and `）， 抓不到…` reading as run-ons with no connective. Both are rewritten. That is the same failure mode that once left a table cell reading `| ，（需要伺服器） |` in this file.

Verified: both files are at zero em dashes, en dashes and horizontal bars; heading count and table row count still match between the two languages; every external link still resolves; 476 tests pass.

Not touched: `js/i18n.js` (100) and `index.html` (5) are user-visible product copy rather than documentation, and `sidecar/README.md` (15) was not in scope here.